### PR TITLE
Bug fix for GitHub actions PR

### DIFF
--- a/.github/actions/commit-issue-action/entrypoint.sh
+++ b/.github/actions/commit-issue-action/entrypoint.sh
@@ -10,7 +10,7 @@ create_issue()
   done
   title="New commit to $INPUT_SOURCEREPO"
   body="There was a new commit/commits to $INPUT_SOURCEREPO, please check the newly updated codebase. Here are the recent commits: $urls"
-  labels=$INPUT_LABELS
+  labels=$INPUT_ISSUELABELS
   json=$(jq -nc --arg l "$labels" --arg t "$title" --arg b "$body" '$l | split(", ") | {title: $t, body: $b, labels: .}')
   issue=$(curl -sS -X POST "$API/repos/$INPUT_TARGETREPO/issues" -H "authorization: token $GITHUB_TOKEN" -H "Content-Type: application/json" -d "$json")
   created=$?
@@ -19,7 +19,7 @@ create_issue()
     exit $created
   else
     echo "Issue created in $INPUT_TARGETREPO"
-    issueURL=$(echo $issue | tr '\n' ' ' | jq -r '.html_url')
+    issueURL=$(jq -n "$issue" | jq -r '.html_url')
     return 0
   fi
 }
@@ -35,7 +35,7 @@ check_commits()
   if [ "$(echo $commits)" = "[ ]" ]; then
     return 1
   else
-    commiturls=$(echo $commits | tr '\n' ' ' | jq -r ".[] | .html_url")
+    commiturls=$(jq -n "$commits" | jq -r ".[] | .html_url")
     return 0
   fi
 }
@@ -54,7 +54,7 @@ main()
       exit 0
     fi
   else
-    echo "No recent commits found."
+    echo "No recent commits found. Response code was $found"
     exit 0
   fi
 }


### PR DESCRIPTION
## Fixed Bugs in GitHub Actions

This pull request (PR) is made in reference to:  #33 #34 #35 #36 

## Description

From the details mentioned in #35, I found a few errors that were not apparent until the action ran properly for the first time. This was due to the scarcity of commits made to `tree-sitter/tree-sitter-python`. It was found that the improper variable name was used for the issue labels in the entrypoint script. The other error was that the statement I had that parsed the json output from the api call was using `echo` which would inevitably cause parsing issues when the commits had newline characters. I worked around this by first using the powerful json parser `jq` to construct a json object that could then be piped through `jq` again to properly filter for the necessary information.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Testing

For testing I just set up the similar configuration on my personal repository and produced the proper results. You can see the end result of the issue being created [here](https://github.com/wescran/commit-issue-action/issues/24)