### PR TITLE
:bug: modify module binding name `tree_sitter_python_legesher_binding'

### DIFF
--- a/bindings/node/index.js
+++ b/bindings/node/index.js
@@ -1,11 +1,11 @@
 try {
-  module.exports = require("../../build/Release/tree_sitter_legesher_python_binding");
+  module.exports = require("../../build/Release/tree_sitter_python_legesher_binding");
 } catch (error1) {
   if (error1.code !== 'MODULE_NOT_FOUND') {
     throw error1;
   }
   try {
-    module.exports = require("../../build/Debug/tree_sitter_legesher_python_binding");
+    module.exports = require("../../build/Debug/tree_sitter_python_legesher_binding");
   } catch (error2) {
     if (error2.code !== 'MODULE_NOT_FOUND') {
       throw error2;


### PR DESCRIPTION
Resolved the issue below by modifying the module name. A new version will be released with this bug fix

[Enter steps to reproduce:]

1. ...
2. ...

**Atom**: 1.57.0 x64
**Electron**: 9.4.4
**OS**: macOS 11.4
**Thrown From**: [language-legesher-python](https://github.com/legesher/language-legesher-python) package 0.58.5


### Stack Trace

Failed to load a language-legesher-python package grammar

```
At Cannot find module '../../build/Release/tree_sitter_legesher_python_binding'
Require stack:
- /../../.atom/packages/language-legesher-python/node_modules/tree-sitter-legesher-python/bindings/node/index.js
- /Applications/Atom.app/Contents/Resources/app.asar/static/index.html in /../../.atom/packages/language-legesher-python/grammars/tree-sitter-legesher-python.cson

Error: Cannot find module '../../build/Release/tree_sitter_legesher_python_binding'
Require stack:
- /../../.atom/packages/language-legesher-python/node_modules/tree-sitter-legesher-python/bindings/node/index.js
- /Applications/Atom.app/Contents/Resources/app.asar/static/index.html
    at Module._resolveFilename (internal/modules/cjs/loader.js:797:17)
    at o._resolveFilename (electron/js2c/renderer_init.js:43:689)
    at Function.get_Module._resolveFilename (/Applications/Atom.app/Contents/Resources/app/static/<embedded>:11:157820)
    at Module.require (/app.asar/static/index.js:61:43)
    at require (/Applications/Atom.app/Contents/Resources/app/static/<embedded>:11:149153)
    at /packages/language-legesher-python/node_modules/tree-sitter-legesher-python/bindings/node/index.js:2:20)
    at /packages/language-legesher-python/node_modules/tree-sitter-legesher-python/bindings/node/index.js:20:3)
    at Module.get_Module._compile (/Applications/Atom.app/Contents/Resources/app/static/<embedded>:11:149837)
    at Object.value [as .js] (/Applications/Atom.app/Contents/Resources/app/static/<embedded>:11:153385)
    at Module.load (internal/modules/cjs/loader.js:815:32)
    at Module._load (internal/modules/cjs/loader.js:727:14)
    at Function.Module._load (electron/js2c/asar.js:769:28)
    at Module.require (/app.asar/static/index.js:72:46)
    at require (internal/modules/cjs/helpers.js:74:18)
    at customRequire (/Applications/Atom.app/Contents/Resources/app/static/<embedded>:1:756278)
    at new TreeSitterGrammar (/Applications/Atom.app/Contents/Resources/app/static/<embedded>:11:3314764)
    at GrammarRegistry.createGrammar (/Applications/Atom.app/Contents/Resources/app/static/<embedded>:11:362880)
    at /Applications/Atom.app/Contents/Resources/app/static/<embedded>:11:362721
    at /Applications/Atom.app/Contents/Resources/app/static/<embedded>:11:585344
    at FSReqCallback.readFileAfterClose [as oncomplete] (internal/fs/read_file_context.js:61:3)
  at /packages/language-legesher-python/grammars/tree-sitter-legesher-python.cson:1:1
```

### Commands

```
```

### Non-Core Packages

```
atom-beautify 0.33.4 
autocomplete-emojis 2.5.0 
busy-signal 2.0.1 
file-icons 2.1.47 
fonts 3.13.0 
intentions 2.1.1 
language-legesher-python 0.58.5 
linter 3.4.0 
linter-eslint 8.6.6 
linter-htmlhint 1.6.3 
linter-python 3.1.2 
linter-ruby 1.3.1 
linter-spell 0.15.0 
linter-spell-html 0.7.0 
linter-ui-default 3.4.1 
pigments 0.40.6 
prettier-atom 0.60.1 
```

