### PR TITLE
Bug: Rust binding with incorrect Language name

### DIFF
--- a/bindings/rust/README.md
+++ b/bindings/rust/README.md
@@ -1,4 +1,4 @@
-# tree-sitter-python
+# tree-sitter-legesher-python
 
 This crate provides a Python grammar for the [tree-sitter][] parsing library.
 To use this crate, add it to the `[dependencies]` section of your `Cargo.toml`
@@ -9,7 +9,7 @@ way.)
 ```toml
 [dependencies]
 tree-sitter = "0.17"
-tree-sitter-python = "0.17"
+tree-sitter-legesher-python = "0.17"
 ```
 
 Typically, you will use the [language][language func] function to add this
@@ -21,16 +21,12 @@ let code = r#"
         return x * 2
 "#;
 let mut parser = Parser::new();
-parser.set_language(tree_sitter_python::language()).expect("Error loading Python grammar");
+parser.set_language(tree_sitter_python_legesher::language()).expect("Error loading Python grammar");
 let parsed = parser.parse(code, None);
 ```
-
-If you have any questions, please reach out to us in the [tree-sitter
-discussions] page.
 
 [language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
 [language func]: https://docs.rs/tree-sitter-python/*/tree_sitter_python/fn.language.html
 [parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
 [tree-sitter]: https://tree-sitter.github.io/
 [tree-sitter crate]: https://crates.io/crates/tree-sitter
-[tree-sitter discussions]: https://github.com/tree-sitter/tree-sitter/discussions

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -30,14 +30,14 @@
 use tree_sitter::Language;
 
 extern "C" {
-    fn tree_sitter_python() -> Language;
+    fn tree_sitter_python_legesher() -> Language;
 }
 
 /// Returns the tree-sitter [Language][] for this grammar.
 ///
 /// [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
 pub fn language() -> Language {
-    unsafe { tree_sitter_python() }
+    unsafe { tree_sitter_python_legesher() }
 }
 
 /// The source of the Python tree-sitter grammar description.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-legesher-python",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "details": {
     "tree-sitter-python-version": "0.19.0",
     "latest-commit": "9b84b7fd9da1aa74c8a8afae58b7dcc4c109cda4"


### PR DESCRIPTION
Received error while used in language-legesher-python package for atom:

```Uncaught (in promise) RangeError: Incompatible language version. Compatible range: 9 - 12. Got: 13
    at Parser.setLanguage (/Applications/Atom.app/Contents/Resources/app.asar/node_modules/tree-sitter/index.js:259)
    at TreeSitterLanguageMode.parse (/Applications/Atom.app/Contents/Resources/app/static/<embedded>:11)
    at LanguageLayer._performUpdate (/Applications/Atom.app/Contents/Resources/app/static/<embedded>:11)
    at LanguageLayer.update (/Applications/Atom.app/Contents/Resources/app/static/<embedded>:11)
    at new TreeSitterLanguageMode (/Applications/Atom.app/Contents/Resources/app/static/<embedded>:11)
    at GrammarRegistry.languageModeForGrammarAndBuffer (/Applications/Atom.app/Contents/Resources/app/static/<embedded>:11)
    at GrammarRegistry.autoAssignLanguageMode (/Applications/Atom.app/Contents/Resources/app/static/<embedded>:11)
    at Project.buildBuffer (/Applications/Atom.app/Contents/Resources/app/static/<embedded>:11)
    at Workspace.openTextFile (/Applications/Atom.app/Contents/Resources/app/static/<embedded>:11)
    at Workspace.createItemForURI (/Applications/Atom.app/Contents/Resources/app/static/<embedded>:11)
    at Workspace.open (/Applications/Atom.app/Contents/Resources/app/static/<embedded>:11) 
```

The `bindings/rust/lib.rs` file did not have the correct Language name passed through.